### PR TITLE
Republishing posts resets publish date

### DIFF
--- a/src/lib/utils/fetchPosts.ts
+++ b/src/lib/utils/fetchPosts.ts
@@ -1,8 +1,26 @@
+import type { SvelteComponent } from 'svelte';
 import { dev } from '$app/environment';
 
 import { postsPerPage } from '$lib/config';
 import type PostsEndpointOptions from '../types/PostsEndpointOptions';
 import type Post from '../types/post';
+
+export const fetchPost = async (
+	slug: string,
+): Promise<{ PostContent: SvelteComponent; meta: Post } | null> => {
+	try {
+		const post = await import(`../content/posts/${slug}.md`);
+
+		return {
+			PostContent: post.default as SvelteComponent,
+			meta: { ...(post.metadata as Post), slug },
+		};
+	} catch (err) {
+		// error(404, `Could not find ${slug}`);
+		console.warn(`Could not find ${slug}`);
+		return null;
+	}
+};
 
 const fetchPosts = async ({
 	offset = 0,
@@ -16,7 +34,7 @@ const fetchPosts = async ({
 			const { metadata } = (await page()) as { metadata: any };
 			const slug = path.split('/').pop()?.split('.').shift();
 			return { ...metadata, slug };
-		})
+		}),
 	);
 
 	if (!dev) posts = posts.filter((post) => post.published === true);

--- a/src/routes/api/v1/posts/constants.ts
+++ b/src/routes/api/v1/posts/constants.ts
@@ -22,6 +22,16 @@ export type PostReqResponse = {
 	status: 'success';
 };
 
+export interface DeriveDatesArgs {
+	currentPostMeta: Post | null | undefined;
+	published: boolean;
+}
+
+export interface DeriveDatesRet {
+	publishedDate: string | undefined;
+	updateDate: string | null;
+}
+
 export interface GetPostTemplateParams {
 	title: string;
 	description: string;

--- a/src/routes/api/v1/posts/constants.ts
+++ b/src/routes/api/v1/posts/constants.ts
@@ -1,3 +1,4 @@
+import type Post from '$lib/types/post';
 import { UsableType } from '../../../(site)/dev/admin/post/subcomponents/UsablesModal/constants';
 import type { Usable } from '../../../(site)/dev/admin/post/subcomponents/UsablesModal/constants';
 
@@ -29,8 +30,7 @@ export interface GetPostTemplateParams {
 	coverImage: string;
 	published: boolean;
 	content: string;
-	publishDate?: string;
-	update?: boolean;
+	currentPostMeta?: Post | null;
 }
 
 export interface ComponentBuilder {

--- a/src/routes/api/v1/posts/logic.test.ts
+++ b/src/routes/api/v1/posts/logic.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, test, expect, beforeEach, vi, afterEach } from 'vitest';
 
 import { hasDefaultScriptMatcher } from './constants';
-import { parseScripts } from './logic';
+import { parseScripts, deriveDates } from './logic';
+import type Post from '$lib/types/post';
 
 const dummyPost = `
 # My Cool Post!
@@ -43,5 +44,82 @@ ${dummyPost}`;
 		const got = parseScripts(content);
 
 		expect(got).toBe(content);
+	});
+});
+
+describe('deriveDates', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	describe("Creating a new post results in now being the post date and no update time (published true/false doesn't matter)", () => {
+		const tests = [{ published: true }, { published: false }];
+
+		test.each(tests)('$published', ({ published }) => {
+			const now = new Date();
+			vi.setSystemTime(now);
+
+			const got = deriveDates({ currentPostMeta: undefined, published });
+
+			expect(got.publishedDate).toBe(now.toString());
+			expect(got.updateDate).toBeNull();
+		});
+	});
+
+	it('resets dates when updating a previously unpublished post to published status', () => {
+		const now = new Date();
+		vi.setSystemTime(now);
+
+		const publishedDate = new Date(2000, 1, 1, 19).toString();
+		const previousPost: Post = {
+			title: 'cool post',
+			published: false,
+			date: publishedDate.toString(),
+		} as Post;
+
+		const got = deriveDates({ currentPostMeta: previousPost, published: true });
+
+		expect(got.publishedDate).toBe(now.toString());
+		expect(got.updateDate).toBeNull();
+	});
+
+	describe('Update scenarios that result in the update time being updated, while preserving the original publish date', () => {
+		const tests = [
+			{
+				description: 'previously unpublished staying unpublished',
+				previousPublishedStatus: false,
+				newPublishedStatus: false,
+			},
+			{
+				description: 'previously published post staying published',
+				previousPublishedStatus: true,
+				newPublishedStatus: true,
+			},
+			{
+				description: 'previously published post switching to unpublished',
+				previousPublishedStatus: true,
+				newPublishedStatus: false,
+			},
+		];
+
+		test.each(tests)('$description', ({ previousPublishedStatus, newPublishedStatus }) => {
+			const now = new Date();
+			vi.setSystemTime(now);
+			const originalPublishDate = new Date(2000, 1, 1, 19).toString();
+			const previousPost: Post = {
+				title: 'cool post',
+				published: previousPublishedStatus,
+				date: originalPublishDate.toString(),
+			} as Post;
+
+			const got = deriveDates({ currentPostMeta: previousPost, published: newPublishedStatus });
+
+			expect(got.publishedDate).toBe(originalPublishDate);
+			expect(got.updateDate).toBe(now.toString());
+		});
 	});
 });

--- a/src/routes/api/v1/posts/logic.ts
+++ b/src/routes/api/v1/posts/logic.ts
@@ -104,8 +104,8 @@ const deriveDates = ({ currentPostMeta, published }: DeriveDatesArgs): DeriveDat
 		return freshPostDates;
 	}
 
-	const republishing = published && !currentPostMeta.published;
-	if (republishing) {
+	const switchingToPublished = published && !currentPostMeta.published;
+	if (switchingToPublished) {
 		return freshPostDates;
 	}
 

--- a/src/routes/api/v1/posts/logic.ts
+++ b/src/routes/api/v1/posts/logic.ts
@@ -6,7 +6,12 @@ import type {
 	RecipeCard,
 	PhotoGallery,
 } from '../../../(site)/dev/admin/post/subcomponents/UsablesModal/constants';
-import type { ComponentBuilder, GetPostTemplateParams } from './constants';
+import type {
+	ComponentBuilder,
+	DeriveDatesArgs,
+	DeriveDatesRet,
+	GetPostTemplateParams,
+} from './constants';
 import { defaultScript, scriptContentMatcher, hasDefaultScriptMatcher } from './constants';
 
 export class UsablesFactory {
@@ -86,16 +91,6 @@ ${contentAfterOriginalScript}`;
 
 const frontMatterArray = (arr: string[]): string =>
 	`[ ${arr.map((item) => `"${item}"`).join(', ')} ]`;
-
-interface DeriveDatesArgs {
-	currentPostMeta: Post | null | undefined;
-	published: boolean;
-}
-
-interface DeriveDatesRet {
-	publishedDate: string | undefined;
-	updateDate: string | null;
-}
 
 const deriveDates = ({ currentPostMeta, published }: DeriveDatesArgs): DeriveDatesRet => {
 	const now = new Date().toString();

--- a/src/routes/api/v1/posts/logic.ts
+++ b/src/routes/api/v1/posts/logic.ts
@@ -92,7 +92,7 @@ ${contentAfterOriginalScript}`;
 const frontMatterArray = (arr: string[]): string =>
 	`[ ${arr.map((item) => `"${item}"`).join(', ')} ]`;
 
-const deriveDates = ({ currentPostMeta, published }: DeriveDatesArgs): DeriveDatesRet => {
+export const deriveDates = ({ currentPostMeta, published }: DeriveDatesArgs): DeriveDatesRet => {
 	const now = new Date().toString();
 	const freshPostDates = {
 		publishedDate: now,


### PR DESCRIPTION
### Current Behavior
Creating a new post creates it with the properties
```
date: creating date (now)
```
Updating the post will always result in the properties
```
date: original creation date (this will never change again)
updated: now
```

### Desired Behavior
We want the above behavior to remain untouched most of the time. However, if an existing post's `published` status is `false` and the user is sending a PATCH request that switches its `published` status to be `true`, we want to "pretend" that the post is being created set the initial published time to `now` and have no updated date.
Initial post
```
published: false
date: 01/01/2020
updated: 01/01/2021

// or for a never before updated post

published: false
date: 01/01/2020
```

after updating the post that happens to also switch `published from `false` to `true`
```
published: true
date: 01/01/2022
```